### PR TITLE
Moved dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 coverage
 npm-debug.log
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,17 @@ COPY scripts ./scripts
 COPY src ./src
 COPY package.json .
 
-RUN npm install --production
+# Install yarn to install and remove dependencies faster
+RUN npm install -g yarn
 
-# Run tests in production environment, will stop image build if tests fail
+# Install dev-dependencies to be able to run tests
+RUN yarn
+
+# Run tests. This will stop the image build if tests fail
 RUN ./scripts/test.sh
+
+# Remove dev dependencies after successful test
+# This is equivalent to 'npm prune --production'
+RUN yarn install --production --ignore-scripts --prefer-offline
 
 ENTRYPOINT [ "bash", "./scripts/entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,7 @@ services:
       NODE_ENV: 'development'
     volumes:
       - ./:/home/node/app
+      # This will prevent node_modules from being mounted
+      - /home/node/app/node_modules/
     ports:
       - 80:8000

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/zappen999/dompen#readme",
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^3.7.1",
     "eslint-config-google": "^0.6.0",
     "eslint-config-standard": "^6.2.0",
@@ -32,10 +33,9 @@
     "eslint-plugin-standard": "^2.0.1",
     "husky": "^0.11.9",
     "istanbul": "^0.4.5",
+    "mocha": "^3.1.2",
+    "nodemon": "^1.11.0",
     "nyc": "^8.3.1"
   },
-  "dependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.1.2"
-  }
+  "dependencies": {}
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,7 +3,7 @@ if [ "$NODE_ENV" = "production" ]; then
   echo "Running in production mode..."
   node --harmony-async-await src/index.js
 elif [ "$NODE_ENV" = "development" ]; then
-  echo "Running in development mode. Installing nodemon..."
-  npm install nodemon -g
-  nodemon --inspect=9222 --harmony-async-await src/index.js
+  echo "Running in development mode. Installing dev-dependencies..."
+  yarn
+  ./node_modules/.bin/nodemon --inspect=9222 --harmony-async-await src/index.js
 fi


### PR DESCRIPTION
### Description
* Container and host will now have separate node_modules. Removed the mount of node_modules between host and container.
* Installed yarn to be able to quickly install and remove dependencies, and avoid hitting the network.
* Dev dependencies are now placed in devDependencies in package.json, as it´s meant to be.
* Moved nodemon to dev dependency instead of global installation.

### Caveats
* Container needs to be restarted in order for new dependencies to be installed, since we don´t mount node_modules any more.

* Yarn might be slower when having few dependencies.