### PR TITLE
Fixed missing production packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ node_modules
 .nyc_output
 coverage
 npm-debug.log
-yarn.lock
 *.pyc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /home/node/app
 COPY scripts ./scripts
 COPY src ./src
 COPY package.json .
+COPY yarn.lock .
 COPY .nycrc .
 
 # Install yarn to install and remove dependencies faster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./src:/home/node/app/src
       - ./scripts:/home/node/app/scripts
       - ./package.json:/home/node/app/package.json
+      - ./yarn.lock:/home/node/app/yarn.lock
       - ./.nycrc:/home/node/app/.nycrc
       - ./coverage:/home/node/app/coverage
     ports:


### PR DESCRIPTION
### Description
Put yarn.lock into version control and mounted it into the container, so that the production environment gets the same packages as development.

### Related issues
#11 