### PR TITLE
Feature/private packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,11 @@ MAINTAINER Johan Kanefur <johan.canefur@gmail.com>
 
 WORKDIR /home/node/app
 
+COPY config/ssh/ /root/.ssh
+RUN chmod -R 400 /root/.ssh
 COPY scripts ./scripts
 COPY src ./src
 COPY package.json .
-COPY yarn.lock .
 COPY .nycrc .
-
-# Install yarn to install and remove dependencies faster
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install yarn
-
-# Install dev-dependencies to be able to run tests
-RUN yarn
-
-# Run tests. This will stop the image build if tests fail
-RUN ./scripts/test.sh
-
-# Remove dev dependencies after successful test
-# This is equivalent to 'npm prune --production'
-RUN yarn install --production --ignore-scripts --prefer-offline
 
 ENTRYPOINT [ "bash", "./scripts/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@
 * Unit testing using [mocha](https://github.com/mochajs/mocha).
 * Generate code coverage reports using [istanbul nyc](https://github.com/istanbuljs/nyc).
 
+### CI/CD Guidance
+You can use these commands in order to test the build before deploying:
+```
+docker build -t dompen .
+docker run -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" -v :w
+```
+
 ## Setup & Usage
 * Install development dependencies with `npm install` (linter configs, pre-commit hooks)
 * Start the container with `docker-compose up`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * Separate `node_modules` between host and container.
 * Unit tests runs in the production environment inside the container.
 * README boilerplate to help with documentation ([found here](service.md)).
+* Mounted SSH agent to be able to pull private dependencies
 
 ### Development environment
 * Support for ES6 (container runs Node 7 with --harmony-async-await).
@@ -22,7 +23,7 @@
 * Start the container with `docker-compose up`
 
 Restart the container when installing new dependencies in package.json
-(or run `yarn` after entering container with `npm run bash`)
+(or run `npm install` after entering container with `npm run bash`)
 
 ### Setting up a service
 The typical flow of setting up a service would be to:<br>
@@ -31,30 +32,6 @@ The typical flow of setting up a service would be to:<br>
 3. Rebase Dompen: `git rebase dompen master`<br>
 4. Keep up with Dompen updates by merging master once in a while: `git merge dompen master`<br>
 5. Replace this `README.md` with `service.md` and fill out the boilerplate documentation<br>
-
-### Build process
-Unit tests executes when building the Docker image. Failing tests will prevent
-the image from being built.
-
-Summary of Docker build sequence:<br>
-1. Copy app into container<br>
-2. Install yarn<br>
-3. Install dependencies<br>
-4. Run unit tests<br>
-5. Remove development dependencies<br>
-6. Start container<br>
-
-When container is started, the entry point script will simply start the
-application if it´s the production environment. Otherwise it will install
-the development dependencies again, and start the server with nodemon and
-debugging server.
-
-Yarn is used instead of npm to quickly install and remove dependencies between
-environments without hitting the network.
-
-Since the node_modules directory isn´t shared between the host and container,
-you must restart the container, or run `npm run reinstall` in order to install
-new dependencies in the container.
 
 ### Scripts
 | **SCRIPT**            | **USAGE**                                           | **CAVEATS**
@@ -65,7 +42,7 @@ new dependencies in the container.
 |**npm run open:cov**   |Opens the code coverage report in the default browser|The container must be running
 |**npm run precommit**  |Runs eslint just like the git precommit hook does    |-
 |**npm run bash**       |Enters the container with bash                       |The container must be running
-|**npm run reinstall**  |Installs dependencies using yarn inside the container|The container must be running
+|**npm run reinstall**  |Installs dependencies inside the container           |The container must be running
 
 ### Testing
 Tests should be placed next to the implementation. Ex:

--- a/config/ssh/config
+++ b/config/ssh/config
@@ -1,0 +1,3 @@
+Host *
+  StrictHostKeyChecking no
+  UserKnownHostsFile=/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     build: .
     environment:
       NODE_ENV: 'development'
+      SSH_AUTH_SOCK: '/tmp/ssh_auth_sock'
     volumes:
       - ./src:/home/node/app/src
       - ./scripts:/home/node/app/scripts
       - ./package.json:/home/node/app/package.json
-      - ./yarn.lock:/home/node/app/yarn.lock
       - ./.nycrc:/home/node/app/.nycrc
       - ./coverage:/home/node/app/coverage
+      - $SSH_AUTH_SOCK:/tmp/ssh_auth_sock
     ports:
-      - 80:8000
       - 9222:9222

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,6 +25,11 @@ trap 'kill ${!}; handler' SIGTERM
 npm install
 ./scripts/test.sh
 
+if [ "$NODE_ENV" = "test" ]; then
+  echo "Running tests..."
+  ./scripts/test.sh
+  echo "Tests passed!"
+  exit 0
 if [ "$NODE_ENV" = "production" ]; then
   echo "Running in production mode..."
   node --harmony-async-await src/index.js &

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -e
+
+echo "Forwarded SSH keys:"
+ssh-add -l
+
 # SIGTERM handler
 handler() {
   if [ $pid -ne 0 ]; then # 0 is the docker entrypoint
@@ -11,15 +16,20 @@ handler() {
   exit 143 # 128 + 15 = SIGTERM
 }
 
+# silence npm
+npm config set loglevel warn
+
 # setup callback handler
 trap 'kill ${!}; handler' SIGTERM
+
+npm install
+./scripts/test.sh
 
 if [ "$NODE_ENV" = "production" ]; then
   echo "Running in production mode..."
   node --harmony-async-await src/index.js &
 elif [ "$NODE_ENV" = "development" ]; then
   echo "Running in development mode. Installing dev-dependencies..."
-  yarn
   ./node_modules/.bin/nodemon --inspect=9222 --harmony-async-await src/index.js &
 fi
 


### PR DESCRIPTION
### Description
Mounts the SSH auth sock into the container to be able to fetch protected dependencies on the hosts behalf (your local SSH key).

### Caveats
* This change is not backward-compatible, meaning that the yarn.lock file will no longer be in use.
* Tests are now executed at runtime before starting the application. The container will shutdown if the tests fail.

### Related issues
#16 
